### PR TITLE
Fix: using sequential instead parallel to avoid no matches found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "rspack:dev": "cross-env NODE_ENV=development rspack build -c .config/rspack.config.js",
     "rspack:prd": "cross-env NODE_ENV=production rspack build -c .config/rspack.config.js",
     "rspack:watch": "cross-env NODE_ENV=development rspack -c .config/rspack.config.js --watch",
-    "css:watch": "npm-run-all -p sass:watch postCss:watch",
+    "css:watch": "npm-run-all -s sass:watch postCss:watch",
     "sass:watch": "sass ./src/assets/scss:dist/assets/css/ --watch",
     "sass:dev": "sass ./src/assets/scss:dist/assets/css/ --no-unicode",
     "sass:prd": "sass ./src/assets/scss:dist/assets/css/ --no-source-map --no-unicode",


### PR DESCRIPTION
Running `yarn start` is failing due to: `No matches found: "./dist/**/*.css"`

`postCss:watch` should be run after `sass:watch`.

![yarn_start_failing](https://github.com/Kazuki-tam/pure-liquid/assets/4956495/b22d99fa-5eda-4b51-b464-0f918313f5a4)

